### PR TITLE
Create exploration endpoint json approach proof of concept

### DIFF
--- a/backend/api/Controllers/ExplorationController.cs
+++ b/backend/api/Controllers/ExplorationController.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 using api.Models;
 using api.Services;
 
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Identity.Web.Resource;
 
@@ -26,16 +28,18 @@ namespace api.Controllers
             _projectService = projectService;
         }
 
-        [HttpGet("{projectId}", Name = "GetExplorations")]
-        public IEnumerable<Exploration> GetExplorations(Guid projectId)
-        {
-            return _explorationService.GetExplorations(projectId);
-        }
-
         [HttpPost(Name = "CreateExploration")]
-        public Exploration CreateExploration([FromBody] Exploration
-                exploration)
+        [Consumes("text/plain")]
+        public Exploration CreateExploration([FromBody] String
+                explorationJson)
         {
+            JsonSerializerOptions options = new()
+            {
+                ReferenceHandler = ReferenceHandler.Preserve,
+            };
+
+            var exploration =
+                JsonSerializer.Deserialize<Exploration>(explorationJson, options);
             return _explorationService.CreateExploration(exploration);
         }
     }

--- a/backend/api/Controllers/ExplorationController.cs
+++ b/backend/api/Controllers/ExplorationController.cs
@@ -14,18 +14,29 @@ namespace api.Controllers
     public class ExplorationController : ControllerBase
     {
         private ExplorationService _explorationService;
+        private ProjectService _projectService;
         private readonly ILogger<ExplorationController> _logger;
 
-        public ExplorationController(ILogger<ExplorationController> logger, ExplorationService explorationProjectService)
+        public ExplorationController(ILogger<ExplorationController> logger,
+                ExplorationService explorationProjectService,
+                ProjectService projectService)
         {
             _logger = logger;
             _explorationService = explorationProjectService;
+            _projectService = projectService;
         }
 
         [HttpGet("{projectId}", Name = "GetExplorations")]
         public IEnumerable<Exploration> GetExplorations(Guid projectId)
         {
             return _explorationService.GetExplorations(projectId);
+        }
+
+        [HttpPost(Name = "CreateExploration")]
+        public Exploration CreateExploration([FromBody] Exploration
+                exploration)
+        {
+            return _explorationService.CreateExploration(exploration);
         }
     }
 }

--- a/backend/api/Controllers/PlainInputFormatter.cs
+++ b/backend/api/Controllers/PlainInputFormatter.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+// cf. https://peterdaugaardrasmussen.com/2020/02/29/asp-net-core-how-to-make-a-controller-endpoint-that-accepts-text-plain/
+
+namespace api.Controllers;
+
+public class TextPlainInputFormatter : InputFormatter
+{
+    private const string ContentType = "text/plain";
+
+    public TextPlainInputFormatter()
+    {
+        SupportedMediaTypes.Add(ContentType);
+    }
+
+    public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+    {
+        var request = context.HttpContext.Request;
+        using (var reader = new StreamReader(request.Body))
+        {
+            var content = await reader.ReadToEndAsync();
+            return await InputFormatterResult.SuccessAsync(content);
+        }
+    }
+
+    public override bool CanRead(InputFormatterContext context)
+    {
+        var contentType = context.HttpContext.Request.ContentType;
+        return contentType.StartsWith(ContentType);
+    }
+}

--- a/backend/api/Controllers/ProjectController.cs
+++ b/backend/api/Controllers/ProjectController.cs
@@ -7,7 +7,7 @@ using Microsoft.Identity.Web.Resource;
 
 namespace api.Controllers
 {
-    [Authorize]
+    //[Authorize]
     [ApiController]
     [Route("[controller]")]
     [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]

--- a/backend/api/Models/Exploration.cs
+++ b/backend/api/Models/Exploration.cs
@@ -9,9 +9,9 @@ namespace api.Models
         public Project Project { get; set; } = null!;
         public string Name { get; set; } = string.Empty;
         public WellType WellType { get; set; }
-        public ExplorationCostProfile CostProfile { get; set; } = null!;
-        public ExplorationDrillingSchedule DrillingSchedule { get; set; } = null!;
-        public GAndGAdminCost GAndGAdminCost { get; set; } = null!;
+        public ExplorationCostProfile? CostProfile { get; set; }
+        public ExplorationDrillingSchedule? DrillingSchedule { get; set; }
+        public GAndGAdminCost? GAndGAdminCost { get; set; }
         public double RigMobDemob { get; set; }
 
     }

--- a/backend/api/Models/Project.cs
+++ b/backend/api/Models/Project.cs
@@ -5,16 +5,16 @@ namespace api.Models
         public Guid Id { get; set; }
         public string ProjectName { get; set; } = string.Empty;
         public DateTimeOffset CreateDate { get; set; }
-        public ICollection<Case> Cases { get; set; } = null!;
-        public ICollection<Surf> Surfs { get; set; } = null!;
-        public ICollection<Substructure> Substructures { get; set; } = null!;
-        public ICollection<Topside> Topsides { get; set; } = null!;
-        public ICollection<Transport> Transports { get; set; } = null!;
+        public ICollection<Case>? Cases { get; set; }
+        public ICollection<Surf>? Surfs { get; set; }
+        public ICollection<Substructure>? Substructures { get; set; }
+        public ICollection<Topside>? Topsides { get; set; }
+        public ICollection<Transport>? Transports { get; set; }
         public ProjectPhase ProjectPhase { get; set; }
         public ProjectCategory ProjectCategory { get; set; }
-        public ICollection<DrainageStrategy> DrainageStrategies { get; set; } = null!;
-        public ICollection<WellProject> WellProjects { get; set; } = null!;
-        public ICollection<Exploration> Explorations { get; set; } = null!;
+        public ICollection<DrainageStrategy>? DrainageStrategies { get; set; }
+        public ICollection<WellProject>? WellProjects { get; set; }
+        public ICollection<Exploration>? Explorations { get; set; }
     }
 
     public enum ProjectPhase

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 
 using api.Context;
+using api.Controllers;
 using api.SampleData.Generators;
 using api.Services;
 
@@ -74,7 +75,9 @@ builder.Services.AddScoped<DrainageStrategyService>();
 builder.Services.AddScoped<WellProjectService>();
 builder.Services.AddScoped<ExplorationService>();
 builder.Services.AddScoped<FacilityService>();
-builder.Services.AddControllers();
+builder.Services.AddControllers((o =>
+    o.InputFormatters.Insert(
+    o.InputFormatters.Count, new TextPlainInputFormatter())));
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/backend/api/Services/ExplorationService.cs
+++ b/backend/api/Services/ExplorationService.cs
@@ -5,13 +5,17 @@ using Microsoft.EntityFrameworkCore;
 
 namespace api.Services
 {
+
     public class ExplorationService
     {
         private readonly DcdDbContext _context;
+        private readonly ProjectService _projectService;
 
-        public ExplorationService(DcdDbContext context)
+        public ExplorationService(DcdDbContext context, ProjectService
+                projectService)
         {
             _context = context;
+            _projectService = projectService;
         }
 
         public IEnumerable<Exploration> GetExplorations(Guid projectId)
@@ -32,6 +36,26 @@ namespace api.Services
                 return new List<Exploration>();
             }
         }
+
+        public Exploration CreateExploration(Exploration exploration)
+        {
+            ValidateExploration(exploration);
+            AddExplorationToProject(exploration);
+            _context.Explorations!.Add(exploration);
+            _context.SaveChanges();
+            return exploration;
+        }
+        private void ValidateExploration(Exploration exploration)
+        {
+            if (exploration == null)
+                throw new ArgumentException("Cannot add a null drainage strategy.");
+            if (exploration.Project == null)
+                throw new ArgumentException("The drainage strategy needs a project.");
+        }
+        private void AddExplorationToProject(Exploration exploration)
+        {
+            var project = _projectService.GetProject(exploration.Project.Id);
+            _projectService.AddExploration(project, exploration);
+        }
     }
 }
-

--- a/backend/api/Services/ExplorationService.cs
+++ b/backend/api/Services/ExplorationService.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 using api.Context;
 using api.Models;
 

--- a/backend/api/Services/ExplorationService.cs
+++ b/backend/api/Services/ExplorationService.cs
@@ -48,9 +48,9 @@ namespace api.Services
         private void ValidateExploration(Exploration exploration)
         {
             if (exploration == null)
-                throw new ArgumentException("Cannot add a null drainage strategy.");
+                throw new ArgumentException("Cannot add a null exploration.");
             if (exploration.Project == null)
-                throw new ArgumentException("The drainage strategy needs a project.");
+                throw new ArgumentException("The exploration needs a project.");
         }
         private void AddExplorationToProject(Exploration exploration)
         {

--- a/backend/api/Services/ProjectService.cs
+++ b/backend/api/Services/ProjectService.cs
@@ -61,6 +61,10 @@ namespace api.Services
             }
             throw new NotFoundInDBException($"The database contains no projects");
         }
+        public void AddExploration(Project project, Exploration exploration)
+        {
+            project.Explorations.Add(exploration);
+        }
         private Project AddAssetsToProject(Project project)
         {
             project.WellProjects = _wellProjectService.GetWellProjects(project.Id).ToList();

--- a/backend/tests/Services/ExplorationServiceShould.cs
+++ b/backend/tests/Services/ExplorationServiceShould.cs
@@ -23,7 +23,7 @@ public class ExplorationServiceTest
     public void CreateNewExplorationCorrectly()
     {
         var project = fixture.context.Projects.FirstOrDefault();
-		var testExploration = CreateTestExploration(project);
+        var testExploration = CreateTestExploration(project);
         ProjectService projectService = new
             ProjectService(fixture.context);
         ExplorationService explorationService = new
@@ -39,23 +39,23 @@ public class ExplorationServiceTest
         compareExplorations(testExploration, retrievedExploration);
     }
 
-	[Fact]
-	public void NotAddExplorationToOtherProjects()
-	{
-		var projectService = new ProjectService(fixture.context);
-		var explorationService = new ExplorationService(fixture.context, projectService);
-		var project = fixture.context.Projects.FirstOrDefault();
-		var expectedExploration = CreateTestExploration(project);
+    [Fact]
+    public void NotAddExplorationToOtherProjects()
+    {
+        var projectService = new ProjectService(fixture.context);
+        var explorationService = new ExplorationService(fixture.context, projectService);
+        var project = fixture.context.Projects.FirstOrDefault();
+        var expectedExploration = CreateTestExploration(project);
 
-		explorationService.CreateExploration(expectedExploration);
+        explorationService.CreateExploration(expectedExploration);
 
-		var otherProjects = fixture.context.Projects.Where(o => o.ProjectName != project.ProjectName);
-		foreach(var otherProject in otherProjects)
-		{
-			var exploration = otherProject.DrainageStrategies.FirstOrDefault(o => o.Name == expectedExploration.Name);
-			Assert.Null(exploration);
-		}
-	}
+        var otherProjects = fixture.context.Projects.Where(o => o.ProjectName != project.ProjectName);
+        foreach (var otherProject in otherProjects)
+        {
+            var exploration = otherProject.DrainageStrategies.FirstOrDefault(o => o.Name == expectedExploration.Name);
+            Assert.Null(exploration);
+        }
+    }
 
     [Fact]
     public void NotCreateExplorationWithoutExplorationDuh()
@@ -72,7 +72,7 @@ public class ExplorationServiceTest
     [Fact]
     public void NotCreateExplorationWithoutProject()
     {
-		var testExploration = CreateTestExploration(null);
+        var testExploration = CreateTestExploration(null);
         ProjectService projectService = new
             ProjectService(fixture.context);
         ExplorationService explorationService = new
@@ -85,11 +85,12 @@ public class ExplorationServiceTest
     [Fact]
     public void NotCreateExplorationIfProjectNotFound()
     {
-        var iDontExistProject = new Project {
+        var iDontExistProject = new Project
+        {
             ProjectName = "never mind",
             Id = new Guid(),
         };
-		var testExploration = CreateTestExploration(iDontExistProject);
+        var testExploration = CreateTestExploration(iDontExistProject);
         ProjectService projectService = new
             ProjectService(fixture.context);
         ExplorationService explorationService = new
@@ -146,12 +147,12 @@ public class ExplorationServiceTest
     private static Exploration CreateTestExploration(Project project)
     {
         return new ExplorationBuilder()
-            {
-                Name = "Test-exploration-23",
-                Project = project,
-                WellType = WellType.Gas,
-                RigMobDemob = 32.7
-            }
+        {
+            Name = "Test-exploration-23",
+            Project = project,
+            WellType = WellType.Gas,
+            RigMobDemob = 32.7
+        }
                 .WithExplorationCostProfile(new ExplorationCostBuilder()
                     .WithYearValue(2023, 44)
                     .WithYearValue(2024, 45.7)

--- a/backend/tests/Services/ExplorationServiceShould.cs
+++ b/backend/tests/Services/ExplorationServiceShould.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Linq;
+
+using api.Models;
+using api.SampleData.Builders;
+using api.Services;
+
+using Xunit;
+
+
+namespace tests;
+
+[Collection("Database collection")]
+public class ExplorationServiceTest
+{
+    DatabaseFixture fixture;
+
+    public ExplorationServiceTest(DatabaseFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+    [Fact]
+    public void CreateNewExplorationCorrectly()
+    {
+        var project = fixture.context.Projects.FirstOrDefault();
+		var testExploration = CreateTestExploration(project);
+        ProjectService projectService = new
+            ProjectService(fixture.context);
+        ExplorationService explorationService = new
+            ExplorationService(fixture.context, projectService);
+
+        explorationService.CreateExploration(testExploration);
+
+        var explorations = fixture.context.Projects.FirstOrDefault(o =>
+                o.ProjectName == project.ProjectName).Explorations;
+        var retrievedExploration = explorations.FirstOrDefault(o => o.Name ==
+                testExploration.Name);
+        Assert.NotNull(retrievedExploration);
+        compareExplorations(testExploration, retrievedExploration);
+    }
+
+	[Fact]
+	public void NotAddExplorationToOtherProjects()
+	{
+		var projectService = new ProjectService(fixture.context);
+		var explorationService = new ExplorationService(fixture.context, projectService);
+		var project = fixture.context.Projects.FirstOrDefault();
+		var expectedExploration = CreateTestExploration(project);
+
+		explorationService.CreateExploration(expectedExploration);
+
+		var otherProjects = fixture.context.Projects.Where(o => o.ProjectName != project.ProjectName);
+		foreach(var otherProject in otherProjects)
+		{
+			var exploration = otherProject.DrainageStrategies.FirstOrDefault(o => o.Name == expectedExploration.Name);
+			Assert.Null(exploration);
+		}
+	}
+
+    [Fact]
+    public void NotCreateExplorationWithoutExplorationDuh()
+    {
+        ProjectService projectService = new
+            ProjectService(fixture.context);
+        ExplorationService explorationService = new
+            ExplorationService(fixture.context, projectService);
+
+        Assert.Throws<ArgumentException>(() =>
+                explorationService.CreateExploration(null));
+    }
+
+    [Fact]
+    public void NotCreateExplorationWithoutProject()
+    {
+		var testExploration = CreateTestExploration(null);
+        ProjectService projectService = new
+            ProjectService(fixture.context);
+        ExplorationService explorationService = new
+            ExplorationService(fixture.context, projectService);
+
+        Assert.Throws<ArgumentException>(() =>
+                explorationService.CreateExploration(testExploration));
+    }
+
+    [Fact]
+    public void NotCreateExplorationIfProjectNotFound()
+    {
+        var iDontExistProject = new Project {
+            ProjectName = "never mind",
+            Id = new Guid(),
+        };
+		var testExploration = CreateTestExploration(iDontExistProject);
+        ProjectService projectService = new
+            ProjectService(fixture.context);
+        ExplorationService explorationService = new
+            ExplorationService(fixture.context, projectService);
+
+        Assert.Throws<NotFoundInDBException>(() =>
+                explorationService.CreateExploration(testExploration));
+    }
+
+
+    void compareExplorations(Exploration expected, Exploration actual)
+    {
+        if (expected == null || actual == null)
+        {
+            Assert.Equal(expected, null);
+            Assert.Equal(actual, null);
+        }
+        else
+        {
+            Assert.Equal(expected.Project.Id, actual.Project.Id);
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.WellType, actual.WellType);
+            compareExplorationCostProfiles(expected.CostProfile, actual.CostProfile);
+            compareExplorationDrillingSchedules(expected.DrillingSchedule,
+                    actual.DrillingSchedule);
+            compareGAndGAdminCosts(expected.GAndGAdminCost,
+                    actual.GAndGAdminCost);
+            Assert.Equal(expected.RigMobDemob, actual.RigMobDemob);
+        }
+    }
+
+    void compareExplorationCostProfiles(ExplorationCostProfile expected, ExplorationCostProfile actual)
+    {
+        Assert.Equal(expected.Currency, actual.Currency);
+        Assert.Equal(expected.EPAVersion, actual.EPAVersion);
+        Assert.Equal(expected.YearValues, actual.YearValues);
+    }
+
+
+    void compareExplorationDrillingSchedules(ExplorationDrillingSchedule expected,
+            ExplorationDrillingSchedule actual)
+    {
+        Assert.Equal(expected.YearValues, actual.YearValues);
+    }
+
+    void compareGAndGAdminCosts(GAndGAdminCost expected,
+            GAndGAdminCost actual)
+    {
+        Assert.Equal(expected.Currency, actual.Currency);
+        Assert.Equal(expected.EPAVersion, actual.EPAVersion);
+        Assert.Equal(expected.YearValues, actual.YearValues);
+    }
+
+    private static Exploration CreateTestExploration(Project project)
+    {
+        return new ExplorationBuilder()
+            {
+                Name = "Test-exploration-23",
+                Project = project,
+                WellType = WellType.Gas,
+                RigMobDemob = 32.7
+            }
+                .WithExplorationCostProfile(new ExplorationCostBuilder()
+                    .WithYearValue(2023, 44)
+                    .WithYearValue(2024, 45.7)
+                )
+                .WithExplorationDrillingSchedule(new ExplorationDrillingScheduleBuilder()
+                    .WithYearValue(2023, 4)
+                    .WithYearValue(2024, 3)
+                )
+                .WithGAndGAdminCost(new WithGAndGAdminCostBuilder()
+                    .WithYearValue(2023, 60.7)
+                    .WithYearValue(2024, 67.4)
+                );
+    }
+
+}

--- a/backend/tests/Services/ProjectService.cs
+++ b/backend/tests/Services/ProjectService.cs
@@ -12,14 +12,20 @@ using Xunit;
 namespace tests
 {
     [Collection("Database collection")]
-    public class ProjectServiceTest
+    public class ProjectServiceTest : IDisposable
     {
         DatabaseFixture fixture;
 
         public ProjectServiceTest(DatabaseFixture fixture)
         {
-            this.fixture = fixture;
+            this.fixture = new DatabaseFixture();
         }
+
+        public void Dispose()
+        {
+            fixture.Dispose();
+        }
+
         [Fact]
         public void GetAll()
         {


### PR DESCRIPTION
ok i think i finally got it. it was a complete pain, and i wasted a lot of time on trying to trick the controller into just getting a string from the body.

i wanted to use this [advice about json and references](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-preserve-references?pivots=dotnet-6-0)
and for that i needed to manually deserialize, mainly as we need to pass an options thingy to the deserializer, and i don't know how to pass that options thingy to the magical hidden controller deserializers.
i finally found a [reference for making controllers accept plain text](https://peterdaugaardrasmussen.com/2020/02/29/asp-net-core-how-to-make-a-controller-endpoint-that-accepts-text-plain/) and applied it. 

now i was able to deserialize manually. and i found this crucial [piece of docs that describes a bit more systematically how this whole reference stuff works](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.serialization.referencehandler.preserve?view=net-6.0)
and here we finally have the piece of info which tells us that this approach won't work: it explains when the data is considered well-formed. consider a costprofile (part of an exploration) referencing the exploration and having some yearvalue data. for the exploration in the cost profile, we would want to just use $ref - but according to the docs
A JSON object that contains a $ref metadata property must not contain any other properties.
so it seems to me that this implies that it won't work like that, since the cost profile needs to both refer to its exploration and convey some other data. (kanskje jeg har misforstått - kurset finner sted lørdag og søndag og, ikke sannt?)

i think this shows that the json approach cannot work - we have a create exploration endpoint which manages to deserialize an exploration json that looks like such:

```json
{
  "$id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "project": {
    "id": "0b612717-bebf-4ca7-a4d3-4bdcda47cb61",
    "projectName": "p1",
    "createDate": "2022-01-27T14:40:48.717Z",
    "projectPhase": 0,
    "projectCategory": 0
  },
  "name": "testExploration",
  "wellType": 2,
  "costProfile": {
    "$ref": "1",
    "yearValues": [
      {
        "id": 0,
        "year": 2012,
        "value": 10
      }
    ],
    "epaVersion": "43",
    "currency": 1
  },
  "rigMobDemob": 0
}
```

this one creates an exploration (feel free to inspect it with that fancy VSCode debugger ; )  ) before passing it on to the service, which fails on validation.

in particular, what caught my eye, is that the cost profile seemed to get deserialized to null : /

i think we'll have to use DTOs.