### PR TITLE
POC for API request/response tests

### DIFF
--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -110,3 +110,5 @@ app.UseCors(_accessControlPolicyName);
 app.MapControllers();
 
 app.Run();
+
+public partial class Program { }

--- a/backend/tests/ApiShould.cs
+++ b/backend/tests/ApiShould.cs
@@ -1,10 +1,11 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
+using api.Models;
+
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using Xunit;
@@ -58,5 +59,10 @@ public class ApiShould : IClassFixture<WebApplicationFactory<Program>>
         response.EnsureSuccessStatusCode(); // Status Code 200-299
         Assert.Equal("application/json; charset=utf-8",
             response.Content.Headers.ContentType.ToString());
+        var responseProjects = await response.Content.ReadFromJsonAsync<List<Project>>();
+        foreach (var responseProject in responseProjects)
+        {
+            Assert.NotNull(responseProject.DrainageStrategies);
+        }
     }
 }

--- a/backend/tests/ApiShould.cs
+++ b/backend/tests/ApiShould.cs
@@ -1,7 +1,7 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
-using api.Models;
+using api.Dtos;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -59,7 +59,7 @@ public class ApiShould : IClassFixture<WebApplicationFactory<Program>>
         response.EnsureSuccessStatusCode(); // Status Code 200-299
         Assert.Equal("application/json; charset=utf-8",
             response.Content.Headers.ContentType.ToString());
-        var responseProjects = await response.Content.ReadFromJsonAsync<List<Project>>();
+        var responseProjects = await response.Content.ReadFromJsonAsync<List<ProjectDto>>();
         foreach (var responseProject in responseProjects)
         {
             Assert.NotNull(responseProject.DrainageStrategies);

--- a/backend/tests/ApiShould.cs
+++ b/backend/tests/ApiShould.cs
@@ -1,0 +1,62 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+namespace inttests;
+
+public class DummyAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public DummyAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions>
+        options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock
+        clock) : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[] { new Claim(ClaimTypes.Name, "Test user") };
+        var identity = new ClaimsIdentity(claims, "Test");
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, "Test");
+
+        var result = AuthenticateResult.Success(ticket);
+
+        return Task.FromResult(result);
+    }
+}
+
+public class ApiShould : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ApiShould(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Theory]
+    [InlineData("/projects")]
+    public async Task Get_EndpointsReturnSuccessAndCorrectContentType(string url)
+    {
+        var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                    {
+                        services.AddAuthentication("Test")
+                        .AddScheme<AuthenticationSchemeOptions, DummyAuthHandler>(
+                            "Test", options => { });
+                    });
+            }).CreateClient();
+        var response = await client.GetAsync(url);
+        response.EnsureSuccessStatusCode(); // Status Code 200-299
+        Assert.Equal("application/json; charset=utf-8",
+            response.Content.Headers.ContentType.ToString());
+    }
+}

--- a/backend/tests/tests.csproj
+++ b/backend/tests/tests.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +16,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pipelines/azure-pipelines-build-and-test.yml
+++ b/pipelines/azure-pipelines-build-and-test.yml
@@ -7,6 +7,11 @@ pr:
 pool:
   vmImage: "ubuntu-latest"
 
+variables:
+  - group: DCD
+  - name: unquotedAppConfigConnectionString
+    value: $[replace(variables['azureAppConfig'], '''', '')]
+
 jobs:
   - job: Lint_CSharp
     continueOnError: true
@@ -76,6 +81,8 @@ jobs:
         inputs:
           command: "test"
           projects: "backend/tests/tests.csproj"
+        env:
+          AppConfiguration__ConnectionString: $(unquotedAppConfigConnectionString)
 
       - script: |
           dotnet tool install JetBrains.dotCover.GlobalTool -g
@@ -83,7 +90,6 @@ jobs:
           dotnet dotcover test
           dotnet dotcover report --source=dotCover.Output.dcvr --reportType=DetailedXml          
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r dotCover.Output.xml
-
         displayName: "Backend Tests With Code Coverage"
   - job: Test_Frontend
     steps:


### PR DESCRIPTION
i managed - just had to expose the `Program` class in `Program.cs`, change the SDK and update a dependency version used in the testing project, and then i could write a test class that spins up a test server (in memory!) which can be queried.

i very much followed the [official docs for integration tests](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-6.0#mock-authentication), and i think i've looked at them a few weeks ago, but i just wasn't ready yet then...

anywho we have a testserver, with a dummy authenticatior injected, and a simple request against projects, which returns good stuff (based on the logs during the test).

Haven't checked yet what made us pursue this path, that's gonna come tomorrow hopefully.

ping @ericnorway @petterwildhagen 

I hope this is usable (to detect the weird behaviour with attach / include), and it's definitely extendable to properly check all the things)