### PR TITLE
Simplify launchsettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,18 @@ The backend is built with .NET 6
 ### Run backend
 
 Create a file `backend/api/Properties/launchSettings.json` with the provided
-template file.
+template file. You need to populate the app configuration connection string
+(navigate to azure portal, find app configuration resource, navigate to
+settings -> access keys), and choose an AppConfiguration Environment (`dev` for
+local development at time of writing).
+
+Finally, to be able to use secrets referenced in the app config, you need to
+authenticate yourself on the command line. [Get a hold of the azure CLI
+`az`](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and run `az
+login` in the command line. NB: You will need to use a browser for the
+authentication, as far as I know.
+
+Then, to start the backend, you can run
 
 ```
 cd backend/api

--- a/backend/api/Properties/launchSettings.template.json
+++ b/backend/api/Properties/launchSettings.template.json
@@ -9,12 +9,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ApplicationInsights__InstrumentationKey": "",
-                "AzureAd__ClientSecret": "",
                 "AppConfiguration__ConnectionString": "",
-                "AppConfiguration__Environment": "",
-                "AZURE_CLIENT_ID": "",
-                "AZURE_TENANT_ID": "",
-                "AZURE_CLIENT_SECRET": ""
+                "AppConfiguration__Environment": ""
             }
         }
     }


### PR DESCRIPTION
for local development of the backend it turns out that we can populate most settings just from the app configuration resource, assuming that we are authenticated in the command line with the `az` CLI.

removed stuff from the launch settings template and described necessary steps in the readme.