### PR TITLE
Feature/remove copydata api

### DIFF
--- a/backend/api/Controllers/DrainageStrategiesController.cs
+++ b/backend/api/Controllers/DrainageStrategiesController.cs
@@ -14,12 +14,10 @@ namespace api.Controllers
     [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
     public class DrainageStrategiesController : ControllerBase
     {
-        private DrainageStrategyService _drainageStrategyService;
-        private readonly ILogger<DrainageStrategiesController> _logger;
+        private readonly DrainageStrategyService _drainageStrategyService;
 
-        public DrainageStrategiesController(ILogger<DrainageStrategiesController> logger, DrainageStrategyService drainageStrategyService)
+        public DrainageStrategiesController(DrainageStrategyService drainageStrategyService)
         {
-            _logger = logger;
             _drainageStrategyService = drainageStrategyService;
         }
 
@@ -36,11 +34,11 @@ namespace api.Controllers
             return _drainageStrategyService.DeleteDrainageStrategy(drainageStrategyId);
         }
 
-        [HttpPut("{drainageStrategyId}", Name = "UpdateDrainageStrategy")]
-        public ProjectDto UpdateDrainageStrategy([FromRoute] Guid drainageStrategyId, [FromBody] DrainageStrategyDto drainageStrategyDto)
+        [HttpPut(Name = "UpdateDrainageStrategy")]
+        public ProjectDto UpdateDrainageStrategy([FromBody] DrainageStrategyDto drainageStrategyDto)
         {
             var drainageStrategy = DrainageStrategyAdapter.Convert(drainageStrategyDto);
-            return _drainageStrategyService.UpdateDrainageStrategy(drainageStrategyId, drainageStrategy);
+            return _drainageStrategyService.UpdateDrainageStrategy(drainageStrategy);
         }
     }
 }

--- a/backend/api/Controllers/ExplorationsController.cs
+++ b/backend/api/Controllers/ExplorationsController.cs
@@ -15,13 +15,10 @@ namespace api.Controllers
     [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
     public class ExplorationsController : ControllerBase
     {
-        private ExplorationService _explorationService;
-        private readonly ILogger<ExplorationsController> _logger;
+        private readonly ExplorationService _explorationService;
 
-        public ExplorationsController(ILogger<ExplorationsController> logger,
-                ExplorationService explorationService)
+        public ExplorationsController(ExplorationService explorationService)
         {
-            _logger = logger;
             _explorationService = explorationService;
         }
 
@@ -38,11 +35,11 @@ namespace api.Controllers
             return _explorationService.DeleteExploration(explorationId);
         }
 
-        [HttpPut("{explorationId}", Name = "UpdateExploration")]
-        public ProjectDto UpdateExploration([FromRoute] Guid explorationId, [FromBody] ExplorationDto eplorationDto)
+        [HttpPut(Name = "UpdateExploration")]
+        public ProjectDto UpdateExploration([FromBody] ExplorationDto eplorationDto)
         {
             var exploration = ExplorationAdapter.Convert(eplorationDto);
-            return _explorationService.UpdateExploration(explorationId, exploration);
+            return _explorationService.UpdateExploration(exploration);
         }
     }
 }

--- a/backend/api/Controllers/ProjectsController.cs
+++ b/backend/api/Controllers/ProjectsController.cs
@@ -14,12 +14,10 @@ namespace api.Controllers
     [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
     public class ProjectsController : ControllerBase
     {
-        private ProjectService _projectService;
-        private readonly ILogger<ProjectsController> _logger;
+        private readonly ProjectService _projectService;
 
-        public ProjectsController(ILogger<ProjectsController> logger, ProjectService projectService)
+        public ProjectsController(ProjectService projectService)
         {
-            _logger = logger;
             _projectService = projectService;
         }
 

--- a/backend/api/Controllers/SubstructuresController.cs
+++ b/backend/api/Controllers/SubstructuresController.cs
@@ -15,13 +15,11 @@ namespace api.Controllers
     [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
     public class SubstructuresController : ControllerBase
     {
-        private SubstructureService _substructureService;
-        private readonly ILogger<SubstructuresController> _logger;
+        private readonly SubstructureService _substructureService;
         private readonly SubstructureAdapter _substructureAdapter;
 
-        public SubstructuresController(ILogger<SubstructuresController> logger, SubstructureService substructureService)
+        public SubstructuresController(SubstructureService substructureService)
         {
-            _logger = logger;
             _substructureService = substructureService;
             _substructureAdapter = new SubstructureAdapter();
         }
@@ -39,11 +37,11 @@ namespace api.Controllers
             return _substructureService.DeleteSubstructure(substructureId);
         }
 
-        [HttpPut("{substructureId}", Name = "UpdateSubstructure")]
-        public ProjectDto UpdateSubstructure([FromRoute] Guid substructureId, [FromBody] SubstructureDto substructureDto)
+        [HttpPut(Name = "UpdateSubstructure")]
+        public ProjectDto UpdateSubstructure([FromBody] SubstructureDto substructureDto)
         {
             var substructure = _substructureAdapter.Convert(substructureDto);
-            return _substructureService.UpdateSubstructure(substructureId, substructure);
+            return _substructureService.UpdateSubstructure(substructure);
         }
     }
 }

--- a/backend/api/Controllers/SurfsController.cs
+++ b/backend/api/Controllers/SurfsController.cs
@@ -19,20 +19,18 @@ namespace api.Controllers
 
         private readonly SurfAdapter _surfAdapter;
 
-        private readonly ILogger<SurfsController> _logger;
 
-        public SurfsController(ILogger<SurfsController> logger, SurfService surfService)
+        public SurfsController(SurfService surfService)
         {
-            _logger = logger;
             _surfService = surfService;
             _surfAdapter = new SurfAdapter();
         }
 
-        [HttpPut("{surfId}", Name = "UpdateSurf")]
-        public ProjectDto UpdateSurf([FromRoute] Guid surfId, [FromBody] SurfDto surfDto)
+        [HttpPut(Name = "UpdateSurf")]
+        public ProjectDto UpdateSurf([FromBody] SurfDto surfDto)
         {
             var surf = _surfAdapter.Convert(surfDto);
-            return _surfService.UpdateSurf(surfId, surf);
+            return _surfService.UpdateSurf(surf);
         }
 
         [HttpPost(Name = "CreateSurf")]

--- a/backend/api/Controllers/TopsidesController.cs
+++ b/backend/api/Controllers/TopsidesController.cs
@@ -16,12 +16,10 @@ namespace api.Controllers
     public class TopsidesController : ControllerBase
     {
         private readonly TopsideService _topsideService;
-        private readonly ILogger<TopsidesController> _logger;
         private readonly TopsideAdapter _topsideAdapter;
 
-        public TopsidesController(ILogger<TopsidesController> logger, TopsideService topsideService)
+        public TopsidesController(TopsideService topsideService)
         {
-            _logger = logger;
             _topsideService = topsideService;
             _topsideAdapter = new TopsideAdapter();
         }
@@ -39,11 +37,11 @@ namespace api.Controllers
             return _topsideService.DeleteTopside(topsideId);
         }
 
-        [HttpPut("{topsideId}", Name = "UpdateTopside")]
-        public ProjectDto UpdateTopside([FromRoute] Guid topsideId, [FromBody] TopsideDto topsideDto)
+        [HttpPut(Name = "UpdateTopside")]
+        public ProjectDto UpdateTopside([FromBody] TopsideDto topsideDto)
         {
             var topside = _topsideAdapter.Convert(topsideDto);
-            return _topsideService.UpdateTopside(topsideId, topside);
+            return _topsideService.UpdateTopside(topside);
         }
     }
 }

--- a/backend/api/Controllers/TransportsController.cs
+++ b/backend/api/Controllers/TransportsController.cs
@@ -15,24 +15,22 @@ namespace api.Controllers
     [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
     public class TransportsController : ControllerBase
     {
-        private readonly ILogger<TransportsController> _logger;
         private readonly TransportService _transportService;
         private readonly TransportAdapter _transportAdapter;
 
-        public TransportsController(ILogger<TransportsController> logger, TransportService transportService)
+        public TransportsController(TransportService transportService)
         {
-            _logger = logger;
             _transportService = transportService;
             _transportAdapter = new TransportAdapter();
 
 
         }
 
-        [HttpPut("{transportId}", Name = "UpdateTransport")]
-        public ProjectDto UpdateTransport([FromRoute] Guid transportId, [FromBody] TransportDto transportDto)
+        [HttpPut(Name = "UpdateTransport")]
+        public ProjectDto UpdateTransport([FromBody] TransportDto transportDto)
         {
             var transport = _transportAdapter.Convert(transportDto);
-            return _transportService.UpdateTransport(transportId, transport);
+            return _transportService.UpdateTransport(transport);
         }
 
         [HttpPost(Name = "CreateTransport")]

--- a/backend/api/Controllers/WellProjectsController.cs
+++ b/backend/api/Controllers/WellProjectsController.cs
@@ -16,12 +16,10 @@ namespace api.Controllers
     public class WellProjectsController : ControllerBase
     {
         private readonly WellProjectService _wellProjectService;
-        private readonly ILogger<WellProjectsController> _logger;
         private readonly WellProjectAdapter _wellProjectAdapter;
 
-        public WellProjectsController(ILogger<WellProjectsController> logger, WellProjectService wellProjectService)
+        public WellProjectsController(WellProjectService wellProjectService)
         {
-            _logger = logger;
             _wellProjectService = wellProjectService;
             _wellProjectAdapter = new WellProjectAdapter();
         }
@@ -39,11 +37,11 @@ namespace api.Controllers
             return _wellProjectService.DeleteWellProject(wellProjectId);
         }
 
-        [HttpPut("{wellProjectId}", Name = "UpdateWellProject")]
-        public ProjectDto UpdateWellProject([FromRoute] Guid wellProjectId, [FromBody] WellProjectDto wellProjectDto)
+        [HttpPut(Name = "UpdateWellProject")]
+        public ProjectDto UpdateWellProject([FromBody] WellProjectDto wellProjectDto)
         {
             var wellProject = _wellProjectAdapter.Convert(wellProjectDto);
-            return _wellProjectService.UpdateWellProject(wellProjectId, wellProject);
+            return _wellProjectService.UpdateWellProject(wellProject);
         }
     }
 }

--- a/backend/api/Services/DrainageStrategyService.cs
+++ b/backend/api/Services/DrainageStrategyService.cs
@@ -78,13 +78,11 @@ namespace api.Services
             }
         }
 
-        public ProjectDto UpdateDrainageStrategy(Guid drainageStrategyId, DrainageStrategy updatedDrainageStrategy)
+        public ProjectDto UpdateDrainageStrategy(DrainageStrategy updatedDrainageStrategy)
         {
-            var drainageStrategy = GetDrainageStrategy(drainageStrategyId);
-            CopyData(drainageStrategy, updatedDrainageStrategy);
-            _context.DrainageStrategies!.Update(drainageStrategy);
+            _context.DrainageStrategies!.Update(updatedDrainageStrategy);
             _context.SaveChanges();
-            return _projectService.GetProjectDto(drainageStrategy.ProjectId);
+            return _projectService.GetProjectDto(updatedDrainageStrategy.ProjectId);
         }
 
         public DrainageStrategy GetDrainageStrategy(Guid drainageStrategyId)

--- a/backend/api/Services/ExplorationService.cs
+++ b/backend/api/Services/ExplorationService.cs
@@ -75,13 +75,11 @@ namespace api.Services
                 }
             }
         }
-        public ProjectDto UpdateExploration(Guid explorationId, Exploration updatedExploration)
+        public ProjectDto UpdateExploration(Exploration updatedExploration)
         {
-            var exploration = GetExploration(explorationId);
-            CopyData(exploration, updatedExploration);
-            _context.Explorations!.Update(exploration);
+            _context.Explorations!.Update(updatedExploration);
             _context.SaveChanges();
-            return _projectService.GetProjectDto(exploration.ProjectId);
+            return _projectService.GetProjectDto(updatedExploration.ProjectId);
         }
 
         public Exploration GetExploration(Guid explorationId)
@@ -97,16 +95,6 @@ namespace api.Services
                 throw new ArgumentException(string.Format("Exploration {0} not found.", explorationId));
             }
             return exploration;
-        }
-
-        private static void CopyData(Exploration exploration, Exploration updatedExploration)
-        {
-            exploration.Name = updatedExploration.Name;
-            exploration.RigMobDemob = updatedExploration.RigMobDemob;
-            exploration.WellType = updatedExploration.WellType;
-            exploration.GAndGAdminCost = updatedExploration.GAndGAdminCost;
-            exploration.DrillingSchedule = updatedExploration.DrillingSchedule;
-            exploration.CostProfile = updatedExploration.CostProfile;
         }
     }
 }

--- a/backend/api/Services/SubstructureService.cs
+++ b/backend/api/Services/SubstructureService.cs
@@ -72,13 +72,11 @@ namespace api.Services
             }
         }
 
-        public ProjectDto UpdateSubstructure(Guid substructureId, Substructure updatedSubstructure)
+        public ProjectDto UpdateSubstructure(Substructure updatedSubstructure)
         {
-            var substructure = GetSubstructure(substructureId);
-            CopyData(substructure, updatedSubstructure);
-            _context.Substructures!.Update(substructure);
+            _context.Substructures!.Update(updatedSubstructure);
             _context.SaveChanges();
-            return _projectService.GetProjectDto(substructure.ProjectId);
+            return _projectService.GetProjectDto(updatedSubstructure.ProjectId);
         }
 
         public Substructure GetSubstructure(Guid substructureId)
@@ -92,17 +90,6 @@ namespace api.Services
                 throw new ArgumentException(string.Format("Substructure {0} not found.", substructureId));
             }
             return substructure;
-        }
-
-        private static void CopyData(Substructure substructure, Substructure updatedSubstructure)
-        {
-            substructure.Name = updatedSubstructure.Name;
-            substructure.DryWeight = updatedSubstructure.DryWeight;
-            substructure.Maturity = updatedSubstructure.Maturity;
-            substructure.CostProfile.Currency = updatedSubstructure.CostProfile.Currency;
-            substructure.CostProfile.EPAVersion = updatedSubstructure.CostProfile.EPAVersion;
-            substructure.CostProfile.StartYear = updatedSubstructure.CostProfile.StartYear;
-            substructure.CostProfile.Values = updatedSubstructure.CostProfile.Values;
         }
     }
 }

--- a/backend/api/Services/SurfService.cs
+++ b/backend/api/Services/SurfService.cs
@@ -32,13 +32,11 @@ namespace api.Services
             }
         }
 
-        public ProjectDto UpdateSurf(Guid surfId, Surf updatedSurf)
+        public ProjectDto UpdateSurf(Surf updatedSurf)
         {
-            var surf = GetSurf(surfId);
-            CopyData(surf, updatedSurf);
-            _context.Surfs!.Update(surf);
+            _context.Surfs!.Update(updatedSurf);
             _context.SaveChanges();
-            return _projectService.GetProjectDto(surf.ProjectId);
+            return _projectService.GetProjectDto(updatedSurf.ProjectId);
         }
         public Surf GetSurf(Guid surfId)
         {
@@ -50,17 +48,6 @@ namespace api.Services
                 throw new ArgumentException(string.Format("Surf {0} not found.", surfId));
             }
             return surf;
-        }
-
-        private static void CopyData(Surf surf, Surf updatedSurf)
-        {
-            surf.Name = updatedSurf.Name;
-            surf.ArtificialLift = updatedSurf.ArtificialLift;
-            surf.Maturity = updatedSurf.Maturity;
-            surf.InfieldPipelineSystemLength = updatedSurf.InfieldPipelineSystemLength;
-            surf.ProductionFlowline = updatedSurf.ProductionFlowline;
-            surf.RiserCount = updatedSurf.RiserCount;
-            surf.CostProfile = updatedSurf.CostProfile;
         }
 
         public ProjectDto CreateSurf(Surf surf, Guid sourceCaseId)

--- a/backend/api/Services/TopsideService.cs
+++ b/backend/api/Services/TopsideService.cs
@@ -72,13 +72,11 @@ namespace api.Services
             }
         }
 
-        public ProjectDto UpdateTopside(Guid topsideId, Topside updatedTopside)
+        public ProjectDto UpdateTopside(Topside updatedTopside)
         {
-            var topside = GetTopside(topsideId);
-            CopyData(topside, updatedTopside);
-            _context.Topsides!.Update(topside);
+            _context.Topsides!.Update(updatedTopside);
             _context.SaveChanges();
-            return _projectService.GetProjectDto(topside.ProjectId);
+            return _projectService.GetProjectDto(updatedTopside.ProjectId);
         }
 
         public Topside GetTopside(Guid topsideId)
@@ -92,21 +90,6 @@ namespace api.Services
                 throw new ArgumentException(string.Format("Topside {0} not found.", topsideId));
             }
             return topside;
-        }
-
-        private static void CopyData(Topside topside, Topside updatedTopside)
-        {
-            topside.Name = updatedTopside.Name;
-            topside.DryWeight = updatedTopside.DryWeight;
-            topside.OilCapacity = updatedTopside.OilCapacity;
-            topside.GasCapacity = updatedTopside.GasCapacity;
-            topside.FacilitiesAvailability = updatedTopside.FacilitiesAvailability;
-            topside.ArtificialLift = updatedTopside.ArtificialLift;
-            topside.Maturity = updatedTopside.Maturity;
-            topside.CostProfile.Currency = updatedTopside.CostProfile.Currency;
-            topside.CostProfile.EPAVersion = updatedTopside.CostProfile.EPAVersion;
-            topside.CostProfile.StartYear = updatedTopside.CostProfile.StartYear;
-            topside.CostProfile.Values = updatedTopside.CostProfile.Values;
         }
     }
 }

--- a/backend/api/Services/TransportService.cs
+++ b/backend/api/Services/TransportService.cs
@@ -83,25 +83,11 @@ namespace api.Services
             }
         }
 
-        public ProjectDto UpdateTransport(Guid transportId, Transport changedtransport)
+        public ProjectDto UpdateTransport(Transport updatedTransport)
         {
-            var transport = GetTransport(transportId);
-            CopyData(transport, changedtransport);
-            _context.Transports!.Update(transport);
+            _context.Transports!.Update(updatedTransport);
             _context.SaveChanges();
-            return _projectService.GetProjectDto(transport.ProjectId);
+            return _projectService.GetProjectDto(updatedTransport.ProjectId);
         }
-
-        private static void CopyData(Transport transport, Transport updatedTransport)
-        {
-            transport.Name = updatedTransport.Name;
-            transport.GasExportPipelineLength = updatedTransport.GasExportPipelineLength;
-            transport.OilExportPipelineLength = updatedTransport.OilExportPipelineLength;
-            transport.Maturity = updatedTransport.Maturity;
-            transport.Project = updatedTransport.Project;
-            transport.ProjectId = updatedTransport.ProjectId;
-            transport.CostProfile = updatedTransport.CostProfile;
-        }
-
     }
 }

--- a/backend/api/Services/WellProjectService.cs
+++ b/backend/api/Services/WellProjectService.cs
@@ -73,13 +73,11 @@ namespace api.Services
             }
         }
 
-        public ProjectDto UpdateWellProject(Guid wellProjectId, WellProject updatedWellProject)
+        public ProjectDto UpdateWellProject(WellProject updatedWellProject)
         {
-            var wellProject = GetWellProject(wellProjectId);
-            CopyData(wellProject, updatedWellProject);
-            _context.WellProjects!.Update(wellProject);
+            _context.WellProjects!.Update(updatedWellProject);
             _context.SaveChanges();
-            return _projectService.GetProjectDto(wellProject.ProjectId);
+            return _projectService.GetProjectDto(updatedWellProject.ProjectId);
         }
 
         public WellProject GetWellProject(Guid wellProjectId)
@@ -93,38 +91,6 @@ namespace api.Services
                 throw new ArgumentException(string.Format("Well project {0} not found.", wellProjectId));
             }
             return wellProject;
-        }
-
-        private static void CopyData(WellProject wellProject, WellProject updatedWellProject)
-        {
-            wellProject.Name = updatedWellProject.Name;
-            wellProject.ProducerCount = updatedWellProject.ProducerCount;
-            wellProject.GasInjectorCount = updatedWellProject.GasInjectorCount;
-            wellProject.WaterInjectorCount = updatedWellProject.WaterInjectorCount;
-            wellProject.ArtificialLift = updatedWellProject.ArtificialLift;
-            wellProject.RigMobDemob = updatedWellProject.RigMobDemob;
-            wellProject.AnnualWellInterventionCost = updatedWellProject.AnnualWellInterventionCost;
-            wellProject.PluggingAndAbandonment = updatedWellProject.PluggingAndAbandonment;
-            if (updatedWellProject.CostProfile != null)
-            {
-                if (wellProject.CostProfile == null)
-                {
-                    wellProject.CostProfile = new WellProjectCostProfile { };
-                }
-                wellProject.CostProfile.Currency = updatedWellProject.CostProfile.Currency;
-                wellProject.CostProfile.EPAVersion = updatedWellProject.CostProfile.EPAVersion;
-                wellProject.CostProfile.Values = updatedWellProject.CostProfile.Values;
-                wellProject.CostProfile.StartYear = updatedWellProject.CostProfile.StartYear;
-            }
-            if (updatedWellProject.DrillingSchedule != null)
-            {
-                if (wellProject.DrillingSchedule == null)
-                {
-                    wellProject.DrillingSchedule = new DrillingSchedule { };
-                }
-                wellProject.DrillingSchedule.Values = updatedWellProject.DrillingSchedule.Values;
-                wellProject.DrillingSchedule.StartYear = updatedWellProject.DrillingSchedule.StartYear;
-            }
         }
     }
 }

--- a/backend/tests/Services/DrainageStrategyServiceShould.cs
+++ b/backend/tests/Services/DrainageStrategyServiceShould.cs
@@ -149,7 +149,7 @@ namespace tests
             var updatedStrategy = CreateUpdatedDrainageStrategy(project);
 
             // Act
-            var projectResult = drainageStrategyService.UpdateDrainageStrategy(oldStrategy.Id, updatedStrategy);
+            var projectResult = drainageStrategyService.UpdateDrainageStrategy(updatedStrategy);
 
             // Assert
             var actualStrategy = projectResult.DrainageStrategies.FirstOrDefault(o => o.Name == updatedStrategy.Name);
@@ -170,7 +170,7 @@ namespace tests
             var updatedStrategy = CreateUpdatedDrainageStrategy(project);
 
             // Act, assert
-            Assert.Throws<ArgumentException>(() => drainageStrategyService.UpdateDrainageStrategy(new Guid(), updatedStrategy));
+            Assert.Throws<ArgumentException>(() => drainageStrategyService.UpdateDrainageStrategy(updatedStrategy));
         }
 
         private static DrainageStrategy CreateTestDrainageStrategy(Project project)

--- a/backend/tests/Services/ExplorationServiceShould.cs
+++ b/backend/tests/Services/ExplorationServiceShould.cs
@@ -104,7 +104,7 @@ public class ExplorationServiceShould : IDisposable
         var updatedExploration = CreateUpdatedTestExploration(project);
 
         // Act
-        var projectResult = explorationService.UpdateExploration(oldExploration.Id, updatedExploration);
+        var projectResult = explorationService.UpdateExploration(updatedExploration);
 
         // Assert
         var actualExploration = projectResult.Explorations.FirstOrDefault(o => o.Name == updatedExploration.Name);

--- a/backend/tests/Services/SubstructureServiceShould.cs
+++ b/backend/tests/Services/SubstructureServiceShould.cs
@@ -140,7 +140,7 @@ namespace tests
             var updatedSubstructure = CreateUpdatedSubstructure(project);
 
             // Act
-            var projectResult = substructureService.UpdateSubstructure(oldSubstructure.Id, updatedSubstructure);
+            var projectResult = substructureService.UpdateSubstructure(updatedSubstructure);
 
             // Assert
             var actualSubstructure = projectResult.Substructures.FirstOrDefault(o => o.Id == oldSubstructure.Id);
@@ -161,7 +161,7 @@ namespace tests
             var updatedSubstructure = CreateUpdatedSubstructure(project);
 
             // Act, assert
-            Assert.Throws<ArgumentException>(() => substructureService.UpdateSubstructure(new Guid(), updatedSubstructure));
+            Assert.Throws<ArgumentException>(() => substructureService.UpdateSubstructure(updatedSubstructure));
         }
 
         private static Substructure CreateTestSubstructure(Project project)

--- a/backend/tests/Services/TopsideServiceShould.cs
+++ b/backend/tests/Services/TopsideServiceShould.cs
@@ -149,7 +149,7 @@ public class TopsideServiceShould : IDisposable
         var updatedTopside = CreateUpdatedTopside(project);
 
         // Act
-        var projectResult = topsideService.UpdateTopside(oldTopside.Id, updatedTopside);
+        var projectResult = topsideService.UpdateTopside(updatedTopside);
 
         // Assert
         var actualTopside = projectResult.Topsides.FirstOrDefault(o => o.Name == updatedTopside.Name);
@@ -170,7 +170,7 @@ public class TopsideServiceShould : IDisposable
         var updatedTopside = CreateUpdatedTopside(project);
 
         // Act, assert
-        Assert.Throws<ArgumentException>(() => topsideService.UpdateTopside(new Guid(), updatedTopside));
+        Assert.Throws<ArgumentException>(() => topsideService.UpdateTopside(updatedTopside));
     }
     private static Topside CreateTestTopside(Project project)
     {

--- a/backend/tests/Services/TransportServiceShould.cs
+++ b/backend/tests/Services/TransportServiceShould.cs
@@ -96,7 +96,7 @@ namespace tests
             var updatedTransport = CreateUpdatedTransport(project);
 
             // Act
-            var projectResult = transportService.UpdateTransport(oldTransport.Id, updatedTransport);
+            var projectResult = transportService.UpdateTransport(updatedTransport);
 
             // Assert
             var actualTransport = projectResult.Transports.FirstOrDefault(o => o.Name == updatedTransport.Name);

--- a/backend/tests/Services/WellProjectServiceShould.cs
+++ b/backend/tests/Services/WellProjectServiceShould.cs
@@ -149,7 +149,7 @@ namespace tests
             var updatedWellProject = CreateUpdatedWellProject(project);
 
             // Act
-            var projectResult = wellProjectService.UpdateWellProject(oldWellProject.Id, updatedWellProject);
+            var projectResult = wellProjectService.UpdateWellProject(updatedWellProject);
 
             // Assert
             var actualWellProject = projectResult.WellProjects.FirstOrDefault(o => o.Name == updatedWellProject.Name);
@@ -170,7 +170,7 @@ namespace tests
             var updatedWellProject = CreateUpdatedWellProject(project);
 
             // Act, assert
-            Assert.Throws<ArgumentException>(() => wellProjectService.UpdateWellProject(new Guid(), updatedWellProject));
+            Assert.Throws<ArgumentException>(() => wellProjectService.UpdateWellProject(updatedWellProject));
         }
 
         private static WellProject CreateTestWellProject(Project project)


### PR DESCRIPTION
This PR removes CopyData from the different asset services in the backend as it is not necessary after changes done on the update action in the controllers.

The update action itself has been updated to only take in the asset dto as a parameter. 