### PR TITLE
Feature/332 create topside asset

### DIFF
--- a/backend/api/Adapters/TopsideAdapter.cs
+++ b/backend/api/Adapters/TopsideAdapter.cs
@@ -25,6 +25,7 @@ namespace api.Adapters
         {
             return new TopsideCostProfile
             {
+                Id = topsideCostProfileDto.Id,
                 Currency = topsideCostProfileDto.Currency,
                 EPAVersion = topsideCostProfileDto.EPAVersion,
                 Topside = topside,

--- a/backend/api/Adapters/TopsideDtoAdapter.cs
+++ b/backend/api/Adapters/TopsideDtoAdapter.cs
@@ -25,6 +25,7 @@ namespace api.Adapters
         {
             return new TopsideCostProfileDto
             {
+                Id = topsideCostProfile.Id,
                 Currency = topsideCostProfile.Currency,
                 EPAVersion = topsideCostProfile.EPAVersion,
                 Values = topsideCostProfile.Values,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import React, { useEffect, useState, VoidFunctionComponent } from "react"
 import { ViewsContainer } from "./Views/ViewsContainer"
 import CaseView from "./Views/CaseView"
 import DashboardView from "./Views/DashboardView"
+import TopsideView from "./Views/TopsideView"
 import ProjectView from "./Views/ProjectView"
 
 import { RetrieveConfigFromAzure } from "./config"
@@ -81,6 +82,10 @@ const App: VoidFunctionComponent = () => {
                             <Route index element={<DashboardView />} />
                             <Route path="project/:projectId" element={<ProjectView />} />
                             <Route path="project/:projectId/case/:caseId" element={<CaseView />} />
+                            <Route 
+                                path="project/:projectId/case/:caseId/topside/:topsideId"
+                                element={<TopsideView/>}>
+                            </Route>
                             <Route
                                 path="project/:projectId/case/:caseId/substructure/:substructureId"
                                 element={<SubstructureView />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,10 +82,10 @@ const App: VoidFunctionComponent = () => {
                             <Route index element={<DashboardView />} />
                             <Route path="project/:projectId" element={<ProjectView />} />
                             <Route path="project/:projectId/case/:caseId" element={<CaseView />} />
-                            <Route 
+                            <Route
                                 path="project/:projectId/case/:caseId/topside/:topsideId"
-                                element={<TopsideView/>}>
-                            </Route>
+                                element={<TopsideView />}
+                            />
                             <Route
                                 path="project/:projectId/case/:caseId/substructure/:substructureId"
                                 element={<SubstructureView />}

--- a/frontend/src/Components/CaseAsset.tsx
+++ b/frontend/src/Components/CaseAsset.tsx
@@ -175,6 +175,14 @@ const CaseAsset = ({
                 >
                     Open
                 </AssetButton>
+                <AssetButton
+                    type="submit"
+                    onClick={
+                        (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => submitCreateAsset(e, "topside")
+                    }
+                >
+                    Create new
+                </AssetButton>
             </Wrapper>
             <Wrapper>
                 <LinkAsset

--- a/frontend/src/Services/TopsideService.ts
+++ b/frontend/src/Services/TopsideService.ts
@@ -9,6 +9,11 @@ export class __TopsideService extends __BaseService {
         const res = await this.postWithParams("", { body }, { params: { sourceCaseId } })
         return Project.fromJSON(res)
     }
+
+    public async updateTopside(body: Components.Schemas.TopsideDto): Promise<Project> {
+        const res = await this.put("", { body })
+        return Project.fromJSON(res)
+    }
 }
 
 export function GetTopsideService() {

--- a/frontend/src/Views/TopsideView.tsx
+++ b/frontend/src/Views/TopsideView.tsx
@@ -64,7 +64,6 @@ const Dg4Field = styled.div`
 `
 
 const TopsideView = () => {
-
     const [, setProject] = useState<Project>()
     const [caseItem, setCase] = useState<Case>()
     const [topside, setTopside] = useState<Topside>()
@@ -79,7 +78,6 @@ const TopsideView = () => {
     const emptyGuid = "00000000-0000-0000-0000-000000000000"
 
     useEffect(() => {
-        
         (async () => {
             try {
                 console.log("UseEffect")
@@ -134,7 +132,6 @@ const TopsideView = () => {
         console.log(newTopside.topsideCostProfile)
     }
 
-
     const handleSave = async () => {
         const topsideDto = Topside.ToDto(topside!)
         if (topside?.id === emptyGuid) {
@@ -177,9 +174,6 @@ const TopsideView = () => {
             <Wrapper><SaveButton disabled={!hasChanges} onClick={handleSave}>Save</SaveButton></Wrapper>
         </AssetViewDiv>
     )
-
-
 }
-
 
 export default TopsideView

--- a/frontend/src/Views/TopsideView.tsx
+++ b/frontend/src/Views/TopsideView.tsx
@@ -80,7 +80,6 @@ const TopsideView = () => {
     useEffect(() => {
         (async () => {
             try {
-                console.log("UseEffect")
                 const projectResult = await GetProjectService().getProjectByID(params.projectId!)
                 setProject(projectResult)
                 const caseResult = projectResult.cases.find((o) => o.id === params.caseId)
@@ -110,25 +109,18 @@ const TopsideView = () => {
     }
 
     const onImport = (input: string, year: number) => {
-        console.log("Before copying")
-        console.log(topside)
         const newTopside = Topside.Copy(topside!)
-        console.log("After copied")
-        console.log(newTopside)
         newTopside.topsideCostProfile!.startYear = year
         newTopside.topsideCostProfile!.epaVersion = ""
         // eslint-disable-next-line max-len
         newTopside.topsideCostProfile!.values = input.replace(/(\r\n|\n|\r)/gm, "").split("\t").map((i) => parseFloat(i))
         setTopside(newTopside)
-        console.log("After setTopside")
-        console.log(newTopside)
         const newColumnTitles = getColumnAbsoluteYears(caseItem, newTopside?.topsideCostProfile)
         setColumns(newColumnTitles)
         const newGridData = buildGridData(newTopside?.topsideCostProfile)
         setGridData(newGridData)
         setCostProfileDialogOpen(!costProfileDialogOpen)
         setHasChanges(true)
-        console.log("onImport ending")
         console.log(newTopside.topsideCostProfile)
     }
 

--- a/frontend/src/Views/TopsideView.tsx
+++ b/frontend/src/Views/TopsideView.tsx
@@ -1,114 +1,185 @@
-import React from "react"
+import { Button, Input, Typography } from "@equinor/eds-core-react"
+import { useEffect, useState } from "react"
+import {
+    useLocation, useNavigate, useParams,
+} from "react-router"
 import styled from "styled-components"
-import { Typography } from "@equinor/eds-core-react"
-
 import DataTable, { CellValue } from "../Components/DataTable/DataTable"
-import { replaceOldData } from "../Components/DataTable/helpers"
+import {
+    buildGridData, getColumnAbsoluteYears, replaceOldData,
+} from "../Components/DataTable/helpers"
+import Import from "../Components/Import/Import"
+import { Topside } from "../models/assets/topside/Topside"
+import { Case } from "../models/Case"
+import { Project } from "../models/Project"
+import { GetProjectService } from "../Services/ProjectService"
+import { GetTopsideService } from "../Services/TopsideService"
 
-const Wrapper = styled.div`
+const AssetHeader = styled.div`
+    margin-bottom: 2rem;
+    display: flex;
+
+    > *:first-child {
+        margin-right: 2rem;
+    }
+`
+
+const AssetViewDiv = styled.div`
+    margin: 2rem;
     display: flex;
     flex-direction: column;
 `
 
-// TODO: This data will have to be generated from the format received from the API
-const initialGridData = [
-    [
-        {
-            readOnly: true,
-            value: "Production profile oil",
-        },
-        { value: 453678 },
-        { value: 383920 },
-        { value: 481726 },
-        { value: 481726 },
-        { value: 363728 },
-    ],
-    [
-        {
-            readOnly: true,
-            value: "Production profile gas",
-        },
-        { value: 678290 },
-        { value: 647382 },
-        { value: 881726 },
-        { value: 363728 },
-        { value: 281726 },
-    ],
-    [
-        {
-            readOnly: true,
-            value: "Production profile water",
-        },
-        { value: 363728 },
-        { value: 281726 },
-        { value: 381723 },
-        { value: 481726 },
-        { value: 363728 },
-    ],
-    [
-        {
-            readOnly: true,
-            value: "Production profile water injection",
-        },
-        { value: 373638 },
-        { value: 237389 },
-        { value: 381724 },
-        { value: 281726 },
-        { value: 373638 },
-    ],
-    [
-        {
-            readOnly: true,
-            value: "Fuel flaring and losses",
-        },
-        { value: 373638 },
-        { value: 237389 },
-        { value: 363728 },
-        { value: 381724 },
-        { value: 281726 },
-    ],
-    [
-        {
-            readOnly: true,
-            value: "Net sales gas",
-        },
-        { value: 373638 },
-        { value: 237389 },
-        { value: 363728 },
-        { value: 281726 },
-        { value: 381724 },
-    ],
-    [
-        {
-            readOnly: true,
-            value: "CO2 emissions",
-        },
-        { value: 373638 },
-        { value: 237389 },
-        { value: 381724 },
-        { value: 281726 },
-        { value: 481726 },
-    ],
-]
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+`
 
-const columnTitles = ["2022", "2023", "2024", "2025", "2026"]
+const WrapperColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+`
 
-function TopsideView() {
-    const [columns, setColumns] = React.useState<string[]>(columnTitles)
-    const [gridData, setGridData] = React.useState<CellValue[][]>(initialGridData)
+const ImportButton = styled(Button)`
+    margin-left: 2rem;
+    &:disabled {
+        margin-left: 2rem;
+    }
+`
 
-    const onCellsChanged = (changes: any[]) => {
+const SaveButton = styled(Button)`
+    margin-top: 5rem;
+    margin-left: 2rem;
+    &:disabled {
+        margin-left: 2rem;
+        margin-top: 5rem;
+    }
+`
+
+const Dg4Field = styled.div`
+    margin-left: 1rem;
+    margin-bottom: 2rem;
+    width: 10rem;
+    display: flex;
+`
+
+const TopsideView = () => {
+
+    const [, setProject] = useState<Project>()
+    const [caseItem, setCase] = useState<Case>()
+    const [topside, setTopside] = useState<Topside>()
+    const [columns, setColumns] = useState<string[]>([""])
+    const [gridData, setGridData] = useState<CellValue[][]>([[]])
+    const [costProfileDialogOpen, setCostProfileDialogOpen] = useState(false)
+    const [hasChanges, setHasChanges] = useState(false)
+    const params = useParams()
+    const navigate = useNavigate()
+    const location = useLocation()
+
+    const emptyGuid = "00000000-0000-0000-0000-000000000000"
+
+    useEffect(() => {
+        
+        (async () => {
+            try {
+                console.log("UseEffect")
+                const projectResult = await GetProjectService().getProjectByID(params.projectId!)
+                setProject(projectResult)
+                const caseResult = projectResult.cases.find((o) => o.id === params.caseId)
+                setCase(caseResult)
+                let newTopside = projectResult.topsides.find((s) => s.id === params.topsideId)
+                if (newTopside !== undefined) {
+                    setTopside(newTopside)
+                } else {
+                    newTopside = new Topside()
+                    setTopside(newTopside)
+                }
+                const newColumnTitles = getColumnAbsoluteYears(caseResult, newTopside?.topsideCostProfile)
+                setColumns(newColumnTitles)
+                const newGridData = buildGridData(newTopside?.topsideCostProfile)
+                setGridData(newGridData)
+            } catch (error) {
+                console.error(`[CaseView] Error while fetching project ${params.projectId}`, error)
+            }
+        })()
+    }, [params.projectId, params.caseId])
+
+    const onCellsChanged = (changes: { cell: { value: number }; col: number; row: number; value: string }[]) => {
         const newGridData = replaceOldData(gridData, changes)
         setGridData(newGridData)
-        setColumns(columnTitles)
+        setColumns(getColumnAbsoluteYears(caseItem, topside?.topsideCostProfile))
+        setHasChanges(true)
+    }
+
+    const onImport = (input: string, year: number) => {
+        console.log("Before copying")
+        console.log(topside)
+        const newTopside = Topside.Copy(topside!)
+        console.log("After copied")
+        console.log(newTopside)
+        newTopside.topsideCostProfile!.startYear = year
+        newTopside.topsideCostProfile!.epaVersion = ""
+        // eslint-disable-next-line max-len
+        newTopside.topsideCostProfile!.values = input.replace(/(\r\n|\n|\r)/gm, "").split("\t").map((i) => parseFloat(i))
+        setTopside(newTopside)
+        console.log("After setTopside")
+        console.log(newTopside)
+        const newColumnTitles = getColumnAbsoluteYears(caseItem, newTopside?.topsideCostProfile)
+        setColumns(newColumnTitles)
+        const newGridData = buildGridData(newTopside?.topsideCostProfile)
+        setGridData(newGridData)
+        setCostProfileDialogOpen(!costProfileDialogOpen)
+        setHasChanges(true)
+        console.log("onImport ending")
+        console.log(newTopside.topsideCostProfile)
+    }
+
+
+    const handleSave = async () => {
+        const topsideDto = Topside.ToDto(topside!)
+        if (topside?.id === emptyGuid) {
+            topsideDto.projectId = params.projectId
+            const newProject = await GetTopsideService().createTopside(params.caseId!, topsideDto!)
+            const newTopside = newProject.topsides.at(-1)
+            const newUrl = location.pathname.replace(emptyGuid, newTopside!.id!)
+            navigate(`${newUrl}`, { replace: true })
+        } else {
+            const newProject = await GetTopsideService().updateTopside(topsideDto!)
+            setProject(newProject)
+            const newCase = newProject.cases.find((o) => o.id === params.caseId)
+            setCase(newCase)
+            const newTopside = newProject.topsides.find((s) => s.id === params.topsideId)
+            setTopside(newTopside)
+        }
+        setHasChanges(false)
     }
 
     return (
-        <Wrapper>
-            <Typography variant="h3">Topside</Typography>
-            <DataTable columns={columns} gridData={gridData} onCellsChanged={onCellsChanged} />
-        </Wrapper>
+        <AssetViewDiv>
+            <AssetHeader>
+                <Typography variant="h2">{topside?.name}</Typography>
+            </AssetHeader>
+            <Wrapper>
+                <Typography variant="h4">DG4</Typography>
+                <Dg4Field>
+                    <Input disabled defaultValue={caseItem?.DG4Date?.toLocaleDateString("en-CA")} type="date" />
+                </Dg4Field>
+            </Wrapper>
+            <Wrapper>
+                <Typography variant="h4">Cost profile</Typography>
+                <ImportButton onClick={() => { setCostProfileDialogOpen(true) }}>Import</ImportButton>
+            </Wrapper>
+            <WrapperColumn>
+                <DataTable columns={columns} gridData={gridData} onCellsChanged={onCellsChanged} />
+            </WrapperColumn>
+            {!costProfileDialogOpen ? null
+                : <Import onClose={() => { setCostProfileDialogOpen(!costProfileDialogOpen) }} onImport={onImport} />}
+            <Wrapper><SaveButton disabled={!hasChanges} onClick={handleSave}>Save</SaveButton></Wrapper>
+        </AssetViewDiv>
     )
+
+
 }
+
 
 export default TopsideView

--- a/frontend/src/Views/TopsideView.tsx
+++ b/frontend/src/Views/TopsideView.tsx
@@ -136,11 +136,15 @@ const TopsideView = () => {
         const topsideDto = Topside.ToDto(topside!)
         if (topside?.id === emptyGuid) {
             topsideDto.projectId = params.projectId
-            const newProject = await GetTopsideService().createTopside(params.caseId!, topsideDto!)
+            const newProject: Project = await GetTopsideService().createTopside(params.caseId!, topsideDto!)
             const newTopside = newProject.topsides.at(-1)
             const newUrl = location.pathname.replace(emptyGuid, newTopside!.id!)
+            const newCase = newProject.cases.find((o) => o.id === params.caseId)
+            setTopside(newTopside)
+            setCase(newCase)
             navigate(`${newUrl}`, { replace: true })
         } else {
+            topsideDto.projectId = params.projectId
             const newProject = await GetTopsideService().updateTopside(topsideDto!)
             setProject(newProject)
             const newCase = newProject.cases.find((o) => o.id === params.caseId)

--- a/frontend/src/Views/TopsideView.tsx
+++ b/frontend/src/Views/TopsideView.tsx
@@ -121,7 +121,6 @@ const TopsideView = () => {
         setGridData(newGridData)
         setCostProfileDialogOpen(!costProfileDialogOpen)
         setHasChanges(true)
-        console.log(newTopside.topsideCostProfile)
     }
 
     const handleSave = async () => {

--- a/frontend/src/models/assets/topside/Topside.ts
+++ b/frontend/src/models/assets/topside/Topside.ts
@@ -4,7 +4,7 @@ export class Topside implements Components.Schemas.TopsideDto {
     id?: string | undefined
     name?: string | null
     projectId?: string | undefined
-    costProfile?: TopsideCostProfile | undefined
+    topsideCostProfile?: TopsideCostProfile | undefined
     dryWeight?: number | undefined
     oilCapacity?: number | undefined
     gasCapacity?: number | undefined
@@ -12,17 +12,37 @@ export class Topside implements Components.Schemas.TopsideDto {
     artificialLift?: Components.Schemas.ArtificialLift | undefined
     maturity?: Components.Schemas.Maturity | undefined
 
-    constructor(data: Components.Schemas.TopsideDto) {
-        this.id = data.id
-        this.name = data.name ?? ""
-        this.projectId = data.projectId
-        this.costProfile = TopsideCostProfile.fromJSON(data.costProfile)
-        this.dryWeight = data.dryWeight
-        this.oilCapacity = data.oilCapacity
-        this.gasCapacity = data.gasCapacity
-        this.facilitiesAvailability = data.facilitiesAvailability
-        this.artificialLift = data.artificialLift
-        this.maturity = data.maturity
+    constructor(data?: Components.Schemas.TopsideDto) {
+        if (data != undefined) {
+            this.id = data.id
+            this.name = data.name ?? ""
+            this.projectId = data.projectId
+            this.topsideCostProfile = TopsideCostProfile.fromJSON(data.costProfile)
+            this.dryWeight = data.dryWeight
+            this.maturity = data.maturity
+        } else {
+            this.id = "00000000-0000-0000-0000-000000000000"
+            this.name = "hehe"
+            this.topsideCostProfile = new TopsideCostProfile()
+            this.topsideCostProfile.epaVersion = ""
+        }
+
+    }
+
+    static Copy(data: Topside) {
+        const topsideCopy = new Topside(data)
+        return {
+            ...topsideCopy,
+            topsideCostProfile: data.topsideCostProfile,
+        }
+    }
+
+    static ToDto(data: Topside): Components.Schemas.TopsideDto {
+        const topsideCopy = new Topside(data)
+        return {
+            ...topsideCopy,
+            costProfile: data.topsideCostProfile,
+        }
     }
 
     static fromJSON(data: Components.Schemas.TopsideDto): Topside {

--- a/frontend/src/models/assets/topside/Topside.ts
+++ b/frontend/src/models/assets/topside/Topside.ts
@@ -13,7 +13,7 @@ export class Topside implements Components.Schemas.TopsideDto {
     maturity?: Components.Schemas.Maturity | undefined
 
     constructor(data?: Components.Schemas.TopsideDto) {
-        if (data != undefined) {
+        if (data !== undefined) {
             this.id = data.id
             this.name = data.name ?? ""
             this.projectId = data.projectId
@@ -26,7 +26,6 @@ export class Topside implements Components.Schemas.TopsideDto {
             this.topsideCostProfile = new TopsideCostProfile()
             this.topsideCostProfile.epaVersion = ""
         }
-
     }
 
     static Copy(data: Topside) {

--- a/frontend/src/models/assets/topside/Topside.ts
+++ b/frontend/src/models/assets/topside/Topside.ts
@@ -22,7 +22,7 @@ export class Topside implements Components.Schemas.TopsideDto {
             this.maturity = data.maturity
         } else {
             this.id = "00000000-0000-0000-0000-000000000000"
-            this.name = "hehe"
+            this.name = ""
             this.topsideCostProfile = new TopsideCostProfile()
             this.topsideCostProfile.epaVersion = ""
         }

--- a/frontend/src/models/assets/topside/TopsideCostProfile.ts
+++ b/frontend/src/models/assets/topside/TopsideCostProfile.ts
@@ -1,4 +1,5 @@
 export class TopsideCostProfile implements Components.Schemas.TopsideCostProfileDto {
+    id?: string 
     startYear?: number | undefined
     values?: number [] | null
     epaVersion?: string | null
@@ -6,11 +7,18 @@ export class TopsideCostProfile implements Components.Schemas.TopsideCostProfile
     sum?: number | undefined
 
     constructor(data?: Components.Schemas.TopsideCostProfileDto) {
-        this.startYear = data?.startYear
-        this.values = data?.values ?? []
-        this.epaVersion = data?.epaVersion ?? null
-        this.currency = data?.currency
-        this.sum = data?.sum
+        
+        if (data != undefined) {
+            this.id = data?.id
+            this.startYear = data?.startYear
+            this.values = data?.values ?? []
+            this.epaVersion = data?.epaVersion ?? null
+            this.currency = data?.currency
+            this.sum = data?.sum
+        } else {
+            this.id = "00000000-0000-0000-0000-000000000000"
+            this.epaVersion = ""
+        }
     }
 
     static fromJSON(data?: Components.Schemas.TopsideCostProfileDto): TopsideCostProfile {

--- a/frontend/src/models/assets/topside/TopsideCostProfile.ts
+++ b/frontend/src/models/assets/topside/TopsideCostProfile.ts
@@ -1,5 +1,5 @@
 export class TopsideCostProfile implements Components.Schemas.TopsideCostProfileDto {
-    id?: string 
+    id?: string
     startYear?: number | undefined
     values?: number [] | null
     epaVersion?: string | null
@@ -7,8 +7,7 @@ export class TopsideCostProfile implements Components.Schemas.TopsideCostProfile
     sum?: number | undefined
 
     constructor(data?: Components.Schemas.TopsideCostProfileDto) {
-        
-        if (data != undefined) {
+        if (data !== undefined) {
             this.id = data?.id
             this.startYear = data?.startYear
             this.values = data?.values ?? []


### PR DESCRIPTION
Reason for case:
- When creating a project, there should be possible to assign a current or existing "Topside", aswell as edit the content.

What has been done:
- Replicated the way Substructure Asset was created with its own View, and added existing fields to datamodels within Frontend and Backend

