### PR TITLE
Align buttons more properly within the different Assets

### DIFF
--- a/frontend/src/Components/TimeSeries.tsx
+++ b/frontend/src/Components/TimeSeries.tsx
@@ -8,7 +8,9 @@ import {
 } from "./DataTable/helpers"
 import Import from "./Import/Import"
 import { ITimeSeries } from "../models/ITimeSeries"
-import { ImportButton, Wrapper, WrapperColumn } from "../Views/Asset/StyledAssetComponents"
+import {
+    DeleteButton, ImportButton, Wrapper, WrapperColumn,
+} from "../Views/Asset/StyledAssetComponents"
 
 interface Props {
     dG4Year: number | undefined
@@ -115,19 +117,22 @@ const TimeSeries = ({
         <>
             <Wrapper>
                 <Typography variant="h4">{timeSeriesTitle}</Typography>
+            </Wrapper>
+            <Wrapper>
                 <ImportButton
                     onClick={() => { setDialogOpen(true) }}
                 >
                     {timeSeries !== undefined ? "Edit" : "Import"}
                 </ImportButton>
-                <ImportButton
+                <DeleteButton
                     disabled={timeSeries === undefined}
                     color="danger"
                     onClick={deleteTimeseries}
                 >
                     Delete
-                </ImportButton>
+                </DeleteButton>
             </Wrapper>
+
             <WrapperColumn>
                 <DataTable
                     columns={columns}

--- a/frontend/src/Views/Asset/StyledAssetComponents.ts
+++ b/frontend/src/Views/Asset/StyledAssetComponents.ts
@@ -51,7 +51,15 @@ export const Dg4Field = styled.div`
 `
 
 export const ImportButton = styled(Button)`
+    width: 10rem;
+    &:disabled {
+        margin-left: 2rem;
+    }
+`
+
+export const DeleteButton = styled(Button)`
     margin-left: 2rem;
+    width: 10rem;
     &:disabled {
         margin-left: 2rem;
     }


### PR DESCRIPTION
Reason for case:
* The "Import/Edit - Delete" buttons were aligned at the end of texts, meaning they would not be displayed the same vertically. 
* Changed some CSS, and moved the buttons out of the Wrapper so it's no longer on the same line as the Tect.

Azure Task:
* https://dev.azure.com/2S-IAF/DCD/_workitems/edit/271