### PR TITLE
Add grayed out background onto Modal

### DIFF
--- a/frontend/src/Components/Modal.tsx
+++ b/frontend/src/Components/Modal.tsx
@@ -27,6 +27,16 @@ export const Modal: FunctionComponent<Props> = ({
     if (!isOpen) return null
     return (
         <Portal>
+            <div style={{
+                position: "fixed",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: "rgba(0,0,0, .7)",
+                zIndex: 1000,
+            }}
+            />
             <FocusOn shards={shards}>
                 <ModalDiv>
                     {title && <Typography variant="h1">{title}</Typography>}


### PR DESCRIPTION
Reason for case:
* When the Modal is popping up, the focus should be on the content within the popup and not around.
* Added a separate grayed out view within the Modal, which can be closed with the "Close" button.

Azure Task:
* https://dev.azure.com/2S-IAF/DCD/_workitems/edit/272