### PR TITLE
Map backend environment to Fusion environment

### DIFF
--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -106,7 +106,13 @@ else
 
 builder.Services.AddFusionIntegration(options =>
 {
-    var fusionEnvironment = config["Fusion:Environment"] ?? "CI";
+    string fusionEnvironment = environment switch
+    {
+        "dev" => "CI",
+        "qa" => "FQA",
+        "prod" => "FPRD",
+        _ => "CI",
+    };
     options.UseServiceInformation("ConceptApp", fusionEnvironment);
 
     options.AddFusionAuthorization();


### PR DESCRIPTION
The different envrionments should now map correctly to the Fusion environments we retrieve projects from.