### PR TITLE
Adding Dynatrace sink to backend project

### DIFF
--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="Serilog.Settings.Configuration" Version="3.5.0-dev-00359" />
         <PackageReference Include="Serilog.Sinks.AzureAnalytics" Version="4.8.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+        <PackageReference Include="Serilog.Sinks.Dynatrace" Version="1.0.5" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
         <PackageReference Include="ClosedXML" Version="0.95.4" />


### PR DESCRIPTION
Adding Dynatrace nuget for Serilog to project, to enable the application
to use Dynatrace sink as destination for logs.