### PR TITLE
Incorrect auth in wait for Radix

### DIFF
--- a/pipelines/templates/stage-deploy-fusion.yml
+++ b/pipelines/templates/stage-deploy-fusion.yml
@@ -106,9 +106,14 @@ stages:
                   inputs:
                       targetType: "inline"
                       script: |
+                          $AzureClientId = "${{ parameters.SpAzureClientId }}"
+                          $AzureTenantId = "${{ parameters.AzureTenantId }}"
+                          $AzureClientSecret = "${{ parameters.SpAzureClientSecret }}"
                           $url = 'https://api.radix.equinor.com/api/v1/applications/dcd/jobs/$(radixJobName)'
+                          az login --service-principal -u $AzureClientId -p $AzureClientSecret --tenant $AzureTenantId  --allow-no-subscriptions
+                          $radixToken = az account get-access-token --resource 6dae42f8-4368-4678-94ff-3960e28e3630 --query=accessToken -otsv
 
-                          $Headers = @{"Authorization" = "Bearer ${{ parameters.radixToken }}"}
+                          $Headers = @{"Authorization" = "Bearer $radixToken"}
 
                           $TimeoutAfter = New-TimeSpan -Minutes 60
                           $WaitBetweenPolling = New-TimeSpan -Seconds 10


### PR DESCRIPTION
Wait for Radix uses still RadixToken, and after cleanup / disable of Token auth fails. Switch to use token from service principal