### PR TITLE
Incorrect auth in wait for Radix

### DIFF
--- a/pipelines/templates/stage-deploy-fusion.yml
+++ b/pipelines/templates/stage-deploy-fusion.yml
@@ -106,7 +106,7 @@ stages:
                   inputs:
                       targetType: "inline"
                       script: |
-                          $AzureClientId = "${{ parameters.SpAzureClientId }}"
+                          $AzureClientId = "${{ parameters.Tjollahopp }}"
                           $AzureTenantId = "${{ parameters.AzureTenantId }}"
                           $AzureClientSecret = "${{ parameters.SpAzureClientSecret }}"
                           $url = 'https://api.radix.equinor.com/api/v1/applications/dcd/jobs/$(radixJobName)'


### PR DESCRIPTION
Wait for Radix uses still RadixToken, and after cleanup / disable of Token auth fails. Switch to use token from service principal