### PR TITLE
bugfix: fix so user can paste a range of cells from excel in to ag grid table

### DIFF
--- a/frontend/src/Components/Case/Components/CaseTabTable.tsx
+++ b/frontend/src/Components/Case/Components/CaseTabTable.tsx
@@ -278,7 +278,6 @@ const CaseTabTable = ({
                         groupIncludeTotalFooter={includeFooter}
                         getRowStyle={getCaseRowStyle}
                         suppressLastEmptyLineOnPaste
-                        singleClickEdit={editMode}
                         stopEditingWhenCellsLoseFocus
                     />
                 </div>

--- a/frontend/src/Components/Case/Components/CaseTabTableWithGrouping.tsx
+++ b/frontend/src/Components/Case/Components/CaseTabTableWithGrouping.tsx
@@ -280,7 +280,6 @@ const CaseTabTableWithGrouping = ({
                         getRowStyle={getRowStyle}
                         suppressLastEmptyLineOnPaste
                         groupDefaultExpanded={groupDefaultExpanded}
-                        singleClickEdit={editMode}
                         stopEditingWhenCellsLoseFocus
                     />
                 </div>


### PR DESCRIPTION
Removed singleClickEdit={editMode} which made it so copied range would paste the range in a single cell instead of the range