### PR TITLE
Remove archived cases from graph in compare cases

### DIFF
--- a/frontend/src/Hooks/useProjectChartData.tsx
+++ b/frontend/src/Hooks/useProjectChartData.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { projectQueryFn, compareCasesQueryFn } from "../Services/QueryFunctions"
 import { useProjectContext } from "../Context/ProjectContext"
@@ -44,19 +44,24 @@ export const useProjectChartData = () => {
         enabled: !!projectId,
     })
 
+    const cases = useMemo(() => 
+        apiData?.cases.filter((c) => !c.archived) || [],
+    [apiData]);
+
     const generateAllCharts = () => {
         if (!compareCasesTotals || !apiData) { return }
-        const npvObject = apiData.cases.map((caseItem) => ({
+        
+        const npvObject = cases.map((caseItem) => ({
             cases: caseItem.name,
             npv: caseItem.npv,
         }))
 
-        const breakEvenObject = apiData.cases.map((caseItem) => ({
+        const breakEvenObject = cases.map((caseItem) => ({
             cases: caseItem.name,
             breakEven: caseItem.breakEven,
         }))
 
-        const productionProfilesObject = apiData.cases.map((caseItem) => {
+        const productionProfilesObject = cases.map((caseItem) => {
             const compareCase = compareCasesTotals.find((c) => c.caseId === caseItem.id)
             return {
                 cases: caseItem.name,
@@ -66,7 +71,7 @@ export const useProjectChartData = () => {
             }
         })
 
-        const investmentProfilesObject = apiData.cases.map((caseItem) => {
+        const investmentProfilesObject = cases.map((caseItem) => {
             const compareCase = compareCasesTotals.find((c) => c.caseId === caseItem.id)
             return {
                 cases: caseItem.name,
@@ -76,7 +81,7 @@ export const useProjectChartData = () => {
             }
         })
 
-        const totalCo2EmissionsObject = apiData.cases.map((caseItem) => {
+        const totalCo2EmissionsObject = cases.map((caseItem) => {
             const compareCase = compareCasesTotals.find((c) => c.caseId === caseItem.id)
             return {
                 cases: caseItem.name,
@@ -84,7 +89,7 @@ export const useProjectChartData = () => {
             }
         })
 
-        const co2IntensityObject = apiData.cases.map((caseItem) => {
+        const co2IntensityObject = cases.map((caseItem) => {
             const compareCase = compareCasesTotals.find((c) => c.caseId === caseItem.id)
             return {
                 cases: caseItem.name,
@@ -105,7 +110,7 @@ export const useProjectChartData = () => {
         if (apiData) {
             const tableCompareCases: TableCompareCase[] = []
             if (compareCasesTotals) {
-                apiData.cases.forEach((c) => {
+                cases.forEach((c) => {
                     const matchingCase = compareCasesTotals.find((checkMatchingCase: any) => checkMatchingCase.caseId === c.id)
                     if (matchingCase) {
                         const tableCase: TableCompareCase = {


### PR DESCRIPTION
[56986](https://statoil-proview.visualstudio.com/Roughtechs/_workitems/edit/56986/)
As I mentioned, yesterday whenever I would filter out the archived cases the bars on the graph would no longer show up. I tested today and that no longer seems to be the case