### PR TITLE
Campaign wells fix

### DIFF
--- a/frontend/src/Components/Case/Tabs/CaseDrillingSchedule/Components/Campaign.tsx
+++ b/frontend/src/Components/Case/Tabs/CaseDrillingSchedule/Components/Campaign.tsx
@@ -26,7 +26,7 @@ const Campaign = ({ tableYears, campaign, title }: CampaignProps) => {
     const { editMode } = useAppStore()
     const { activeTabCase } = useCaseStore()
 
-    const allWells = useMemo(() => filterWells(revisionAndProjectData?.commonProjectAndRevisionData.wells ?? []), [revisionAndProjectData, activeTabCase])
+    const allWells = useMemo(() => filterWells(revisionAndProjectData?.commonProjectAndRevisionData.wells ?? []), [revisionAndProjectData])
     const canUserEdit = useMemo(() => canEdit(), [canEdit, activeTabCase, editMode])
 
     const generateRowData = (): ItimeSeriesTableDataWithWell[] => {

--- a/frontend/src/Components/Case/Tabs/CaseDrillingSchedule/Components/Campaign.tsx
+++ b/frontend/src/Components/Case/Tabs/CaseDrillingSchedule/Components/Campaign.tsx
@@ -16,6 +16,7 @@ import { useDataFetch } from "@/Hooks/useDataFetch"
 import { filterWells } from "@/Utils/common"
 import useCanUserEdit from "@/Hooks/useCanUserEdit"
 import { useAppStore } from "@/Store/AppStore"
+import { useCaseStore } from "@/Store/CaseStore"
 
 const Campaign = ({ tableYears, campaign, title }: CampaignProps) => {
     const { apiData } = useCaseApiData()
@@ -23,8 +24,10 @@ const Campaign = ({ tableYears, campaign, title }: CampaignProps) => {
     const revisionAndProjectData = useDataFetch()
     const { canEdit } = useCanUserEdit()
     const { editMode } = useAppStore()
+    const { activeTabCase } = useCaseStore()
 
-    const allWells = useMemo(() => filterWells(revisionAndProjectData?.commonProjectAndRevisionData.wells ?? []), [revisionAndProjectData])
+    const allWells = useMemo(() => filterWells(revisionAndProjectData?.commonProjectAndRevisionData.wells ?? []), [revisionAndProjectData, activeTabCase])
+    const canUserEdit = useMemo(() => canEdit(), [canEdit, activeTabCase, editMode])
 
     const generateRowData = (): ItimeSeriesTableDataWithWell[] => {
         const rows: ITimeSeriesTableData[] = []
@@ -81,7 +84,7 @@ const Campaign = ({ tableYears, campaign, title }: CampaignProps) => {
             rows.push(wellRow)
         })
 
-        if (canEdit() && title === "Exploration") {
+        if (canUserEdit && title === "Exploration") {
             allWells.explorationWells.forEach((well: Components.Schemas.WellOverviewDto) => {
                 const wellRow: ItimeSeriesTableDataWithWell = {
                     profileName: well.name,
@@ -101,7 +104,7 @@ const Campaign = ({ tableYears, campaign, title }: CampaignProps) => {
             })
         }
 
-        if (canEdit() && title === "Development") {
+        if (canUserEdit && title === "Development") {
             allWells.developmentWells.forEach((well: Components.Schemas.WellOverviewDto) => {
                 const wellRow: ItimeSeriesTableDataWithWell = {
                     profileName: well.name,
@@ -124,7 +127,7 @@ const Campaign = ({ tableYears, campaign, title }: CampaignProps) => {
         return rows
     }
 
-    const rowData = useMemo(() => generateRowData(), [campaign, tableYears, editMode])
+    const rowData = useMemo(() => generateRowData(), [campaign, tableYears, canUserEdit])
 
     if (!apiData) {
         return <ProjectSkeleton />

--- a/frontend/src/Components/Tables/CaseTables/CaseTabTable.tsx
+++ b/frontend/src/Components/Tables/CaseTables/CaseTabTable.tsx
@@ -41,7 +41,6 @@ import {
 } from "@/Models/ITimeSeries"
 import { gridRefArrayToAlignedGrid, profilesToRowData } from "@/Components/AgGrid/AgGridHelperFunctions"
 import SidesheetWrapper from "../TableSidesheet/SidesheetWrapper"
-import useEditCase from "@/Hooks/useEditCase"
 import { useTableQueue } from "@/Hooks/useTableQueue"
 import useCanUserEdit from "@/Hooks/useCanUserEdit"
 
@@ -92,7 +91,6 @@ const CaseTabTable = memo(({
     const styles = useStyles()
     const { caseId, tab } = useParams()
     const { projectId } = useProjectContext()
-    const { addEdit } = useEditCase()
     const { canEdit, isEditDisabled } = useCanUserEdit()
 
     // State Management

--- a/frontend/src/Hooks/UseSubmitToApi.tsx
+++ b/frontend/src/Hooks/UseSubmitToApi.tsx
@@ -150,45 +150,45 @@ export const useSubmitToApi = () => {
         try {
             const result = await (async () => {
                 switch (resourceName) {
-                    case "case":
-                        return updateCase({
-                            projectId, caseId, resourceObject,
-                        })
+                case "case":
+                    return updateCase({
+                        projectId, caseId, resourceObject,
+                    })
 
-                    case "caseProfiles":
-                        return updateCaseProfiles({
-                            projectId, caseId, resourceObject,
-                        })
+                case "caseProfiles":
+                    return updateCaseProfiles({
+                        projectId, caseId, resourceObject,
+                    })
 
-                    case "topside":
-                        return updateTopside({
-                            projectId, caseId, resourceObject,
-                        })
+                case "topside":
+                    return updateTopside({
+                        projectId, caseId, resourceObject,
+                    })
 
-                    case "surf":
-                        return updateSurf({
-                            projectId, caseId, resourceObject,
-                        })
+                case "surf":
+                    return updateSurf({
+                        projectId, caseId, resourceObject,
+                    })
 
-                    case "substructure":
-                        return updateSubstructure({
-                            projectId, caseId, resourceObject,
-                        })
+                case "substructure":
+                    return updateSubstructure({
+                        projectId, caseId, resourceObject,
+                    })
 
-                    case "transport":
-                        return updateTransport({
-                            projectId, caseId, resourceObject,
-                        })
+                case "transport":
+                    return updateTransport({
+                        projectId, caseId, resourceObject,
+                    })
 
-                    case "onshorePowerSupply":
-                        return updateOnshorePowerSupply({
-                            projectId, caseId, resourceObject,
-                        })
+                case "onshorePowerSupply":
+                    return updateOnshorePowerSupply({
+                        projectId, caseId, resourceObject,
+                    })
 
-                    case "drainageStrategy":
-                        return updateDrainageStrategy({
-                            projectId, caseId, resourceObject,
-                        })
+                case "drainageStrategy":
+                    return updateDrainageStrategy({
+                        projectId, caseId, resourceObject,
+                    })
 
                 case "rigUpgrading":
                     return updateCampaign({
@@ -227,8 +227,8 @@ export const useSubmitToApi = () => {
                         resourceObject,
                     })
 
-                    default:
-                        console.log("Resource name not found", resourceName)
+                default:
+                    console.log("Resource name not found", resourceName)
                 }
 
                 return { success: false, error: new Error("Service not found") }

--- a/frontend/src/Views/CaseView.tsx
+++ b/frontend/src/Views/CaseView.tsx
@@ -11,7 +11,7 @@ import CaseCostTab from "@/Components/Case/Tabs/CaseCost/CaseCostTab"
 import CaseScheduleTab from "@/Components/Case/Tabs/CaseScheduleTab"
 import CaseSummaryTab from "@/Components/Case/Tabs/CaseSummaryTab"
 import { useCaseStore } from "@/Store/CaseStore"
-import { useDataFetch, useEditCase, useLocalStorage } from "@/Hooks"
+import { useDataFetch, useLocalStorage } from "@/Hooks"
 import { caseTabNames } from "@/Utils/constants"
 import { useAppNavigation } from "@/Hooks/useNavigate"
 
@@ -20,7 +20,6 @@ const Wrapper = styled(Grid2)`
 `
 const CaseView = () => {
     const { caseId, tab } = useParams()
-    const { addEdit } = useEditCase()
     const revisionAndProjectData = useDataFetch()
     const {
         activeTabCase,


### PR DESCRIPTION
fix: when changing more than one well in campaigns there should only be one request to backend, as the endpoint allows for array of wells

fix: when in edit mode in another tab (for example cost), switching to drilling schedule will not show all wells until you toggle edit mode again